### PR TITLE
Mockable

### DIFF
--- a/Reachability.swift
+++ b/Reachability.swift
@@ -56,6 +56,7 @@ public class Reachability: NSObject, Printable {
     public var whenReachable: NetworkReachable?
     public var whenUnreachable: NetworkUneachable?
     public var reachableOnWWAN: Bool
+    public var notificationCenter = NSNotificationCenter.defaultCenter()
 
     public var currentReachabilityStatus: NetworkStatus {
         if isReachable() {
@@ -232,7 +233,7 @@ public class Reachability: NSObject, Printable {
             }
         }
 
-        NSNotificationCenter.defaultCenter().postNotificationName(ReachabilityChangedNotification, object:self)
+        notificationCenter.postNotificationName(ReachabilityChangedNotification, object:self)
     }
 
     private func isReachableWithFlags(flags: SCNetworkReachabilityFlags) -> Bool {

--- a/Reachability.swift
+++ b/Reachability.swift
@@ -75,6 +75,12 @@ public class Reachability: NSObject, Printable {
     }
 
     // MARK: - *** Initialisation methods ***
+    
+    public required init(reachabilityRef: SCNetworkReachability) {
+        reachableOnWWAN = true
+        self.reachabilityRef = reachabilityRef
+    }
+    
     public convenience init(hostname: String) {
         let ref = SCNetworkReachabilityCreateWithName(nil, (hostname as NSString).UTF8String).takeRetainedValue()
         self.init(reachabilityRef: ref)
@@ -202,11 +208,6 @@ public class Reachability: NSObject, Printable {
         return dispatch_queue_create("uk.co.joylordsystems.reachability_timer_queue", nil)
         }()
     private var previousReachabilityFlags: SCNetworkReachabilityFlags?
-
-    private init(reachabilityRef: SCNetworkReachability) {
-        reachableOnWWAN = true
-        self.reachabilityRef = reachabilityRef
-    }
 
     func timerFired() {
         let currentReachabilityFlags = reachabilityFlags


### PR DESCRIPTION
In order to test applications that use Reachability I use a mock object which is a subclass of Reachability that allows me to override certain methods.

Since Reachability doesn't have a public designated initialiser as it stands I can't create a subclass.

This PR declares a public designated initialiser.

Secondly, I have added a var for the `NSNotificatonCenter` to use for posting notifications. This defaults to the `defaultCenter` but can be overriden if required. This is useful for testing and also gives more flexibility to consumers to choose which centre to use for listening to reachability notifications.