### PR TITLE
Make the project compatible with Carthage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Replacement for Apple's Reachability re-written in Swift with closures
 
-Inspired by https://github.com/tonymillion/Reachability 
+Inspired by https://github.com/tonymillion/Reachability
+
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 **NOTES:**
 

--- a/Reachability Sample/Reachability Sample.xcodeproj/project.pbxproj
+++ b/Reachability Sample/Reachability Sample.xcodeproj/project.pbxproj
@@ -7,13 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A19CAA51B0E999E00548B1A /* Reachability.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A19CAA41B0E999E00548B1A /* Reachability.framework */; };
+		0A19CAA61B0E999E00548B1A /* Reachability.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0A19CAA41B0E999E00548B1A /* Reachability.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CA25599F19D0D1990073826D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA25599E19D0D1990073826D /* AppDelegate.swift */; };
 		CA2559A119D0D1990073826D /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2559A019D0D1990073826D /* ViewController.swift */; };
 		CA2559A419D0D1990073826D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CA2559A219D0D1990073826D /* Main.storyboard */; };
 		CA2559A619D0D1990073826D /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CA2559A519D0D1990073826D /* Images.xcassets */; };
 		CA2559A919D0D1990073826D /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = CA2559A719D0D1990073826D /* LaunchScreen.xib */; };
 		CA2559B519D0D1990073826D /* Reachability_SampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2559B419D0D1990073826D /* Reachability_SampleTests.swift */; };
-		CA2559BF19D0D1AF0073826D /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2559BE19D0D1AF0073826D /* Reachability.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -26,7 +27,22 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		0A19CAA71B0E999E00548B1A /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				0A19CAA61B0E999E00548B1A /* Reachability.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		0A19CAA41B0E999E00548B1A /* Reachability.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Reachability.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA25599919D0D1990073826D /* Reachability Sample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Reachability Sample.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA25599D19D0D1990073826D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CA25599E19D0D1990073826D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -37,7 +53,6 @@
 		CA2559AE19D0D1990073826D /* Reachability SampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Reachability SampleTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA2559B319D0D1990073826D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CA2559B419D0D1990073826D /* Reachability_SampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reachability_SampleTests.swift; sourceTree = "<group>"; };
-		CA2559BE19D0D1AF0073826D /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reachability.swift; path = ../../Reachability.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -45,6 +60,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A19CAA51B0E999E00548B1A /* Reachability.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -61,6 +77,7 @@
 		CA25599019D0D1990073826D = {
 			isa = PBXGroup;
 			children = (
+				0A19CAA41B0E999E00548B1A /* Reachability.framework */,
 				CA25599B19D0D1990073826D /* Reachability Sample */,
 				CA2559B119D0D1990073826D /* Reachability SampleTests */,
 				CA25599A19D0D1990073826D /* Products */,
@@ -79,7 +96,6 @@
 		CA25599B19D0D1990073826D /* Reachability Sample */ = {
 			isa = PBXGroup;
 			children = (
-				CA2559BE19D0D1AF0073826D /* Reachability.swift */,
 				CA25599E19D0D1990073826D /* AppDelegate.swift */,
 				CA2559A019D0D1990073826D /* ViewController.swift */,
 				CA2559A219D0D1990073826D /* Main.storyboard */,
@@ -125,6 +141,7 @@
 				CA25599519D0D1990073826D /* Sources */,
 				CA25599619D0D1990073826D /* Frameworks */,
 				CA25599719D0D1990073826D /* Resources */,
+				0A19CAA71B0E999E00548B1A /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -217,7 +234,6 @@
 			files = (
 				CA2559A119D0D1990073826D /* ViewController.swift in Sources */,
 				CA25599F19D0D1990073826D /* AppDelegate.swift in Sources */,
-				CA2559BF19D0D1AF0073826D /* Reachability.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -342,6 +358,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/Reachability-diymfgdhtrybbbbasrmxgqyczjei/Build/Products/Debug-iphoneos",
+				);
 				INFOPLIST_FILE = "Reachability Sample/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -352,6 +372,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/Reachability-diymfgdhtrybbbbasrmxgqyczjei/Build/Products/Debug-iphoneos",
+				);
 				INFOPLIST_FILE = "Reachability Sample/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Reachability Sample/Reachability Sample/ViewController.swift
+++ b/Reachability Sample/Reachability Sample/ViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Reachability
 
 let useClosures = false
 

--- a/Reachability.xcodeproj/project.pbxproj
+++ b/Reachability.xcodeproj/project.pbxproj
@@ -1,0 +1,400 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0A19CA831B0E970E00548B1A /* Reachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A19CA821B0E970E00548B1A /* Reachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0A19CA9A1B0E973400548B1A /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A19CA991B0E973400548B1A /* Reachability.swift */; };
+		0A19CAC61B0E9B2800548B1A /* Reachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A19CA821B0E970E00548B1A /* Reachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0A19CAC71B0E9B3200548B1A /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A19CA991B0E973400548B1A /* Reachability.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		0A19CA7D1B0E970E00548B1A /* Reachability.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Reachability.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0A19CA811B0E970E00548B1A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0A19CA821B0E970E00548B1A /* Reachability.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Reachability.h; sourceTree = "<group>"; };
+		0A19CA991B0E973400548B1A /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reachability.swift; path = ../../../../../../../../src/Reachability.swift/Reachability.swift; sourceTree = BUILT_PRODUCTS_DIR; };
+		0A19CAAD1B0E9ADA00548B1A /* Reachability.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Reachability.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0A19CA791B0E970E00548B1A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0A19CAA91B0E9ADA00548B1A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0A19CA731B0E970E00548B1A = {
+			isa = PBXGroup;
+			children = (
+				0A19CA7F1B0E970E00548B1A /* Reachability */,
+				0A19CA7E1B0E970E00548B1A /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		0A19CA7E1B0E970E00548B1A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0A19CA7D1B0E970E00548B1A /* Reachability.framework */,
+				0A19CAAD1B0E9ADA00548B1A /* Reachability.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		0A19CA7F1B0E970E00548B1A /* Reachability */ = {
+			isa = PBXGroup;
+			children = (
+				0A19CA821B0E970E00548B1A /* Reachability.h */,
+				0A19CA991B0E973400548B1A /* Reachability.swift */,
+				0A19CA801B0E970E00548B1A /* Supporting Files */,
+			);
+			path = Reachability;
+			sourceTree = "<group>";
+		};
+		0A19CA801B0E970E00548B1A /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				0A19CA811B0E970E00548B1A /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		0A19CA7A1B0E970E00548B1A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0A19CA831B0E970E00548B1A /* Reachability.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0A19CAAA1B0E9ADA00548B1A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0A19CAC61B0E9B2800548B1A /* Reachability.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		0A19CA7C1B0E970E00548B1A /* Reachability-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0A19CA931B0E970E00548B1A /* Build configuration list for PBXNativeTarget "Reachability-iOS" */;
+			buildPhases = (
+				0A19CA781B0E970E00548B1A /* Sources */,
+				0A19CA791B0E970E00548B1A /* Frameworks */,
+				0A19CA7A1B0E970E00548B1A /* Headers */,
+				0A19CA7B1B0E970E00548B1A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Reachability-iOS";
+			productName = Reachability;
+			productReference = 0A19CA7D1B0E970E00548B1A /* Reachability.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		0A19CAAC1B0E9ADA00548B1A /* Reachability-Mac */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0A19CAC01B0E9ADA00548B1A /* Build configuration list for PBXNativeTarget "Reachability-Mac" */;
+			buildPhases = (
+				0A19CAA81B0E9ADA00548B1A /* Sources */,
+				0A19CAA91B0E9ADA00548B1A /* Frameworks */,
+				0A19CAAA1B0E9ADA00548B1A /* Headers */,
+				0A19CAAB1B0E9ADA00548B1A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Reachability-Mac";
+			productName = "Reachability-Mac";
+			productReference = 0A19CAAD1B0E9ADA00548B1A /* Reachability.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0A19CA741B0E970E00548B1A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0630;
+				ORGANIZATIONNAME = Shutl;
+				TargetAttributes = {
+					0A19CA7C1B0E970E00548B1A = {
+						CreatedOnToolsVersion = 6.3.2;
+					};
+					0A19CAAC1B0E9ADA00548B1A = {
+						CreatedOnToolsVersion = 6.3.2;
+					};
+				};
+			};
+			buildConfigurationList = 0A19CA771B0E970E00548B1A /* Build configuration list for PBXProject "Reachability" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 0A19CA731B0E970E00548B1A;
+			productRefGroup = 0A19CA7E1B0E970E00548B1A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				0A19CA7C1B0E970E00548B1A /* Reachability-iOS */,
+				0A19CAAC1B0E9ADA00548B1A /* Reachability-Mac */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		0A19CA7B1B0E970E00548B1A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0A19CAAB1B0E9ADA00548B1A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0A19CA781B0E970E00548B1A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0A19CA9A1B0E973400548B1A /* Reachability.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0A19CAA81B0E9ADA00548B1A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0A19CAC71B0E9B3200548B1A /* Reachability.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		0A19CA911B0E970E00548B1A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		0A19CA921B0E970E00548B1A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		0A19CA941B0E970E00548B1A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Reachability/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = Reachability;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		0A19CA951B0E970E00548B1A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Reachability/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = Reachability;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		0A19CAC11B0E9ADA00548B1A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = Reachability/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_NAME = Reachability;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		0A19CAC21B0E9ADA00548B1A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = Reachability/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_NAME = Reachability;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0A19CA771B0E970E00548B1A /* Build configuration list for PBXProject "Reachability" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0A19CA911B0E970E00548B1A /* Debug */,
+				0A19CA921B0E970E00548B1A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0A19CA931B0E970E00548B1A /* Build configuration list for PBXNativeTarget "Reachability-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0A19CA941B0E970E00548B1A /* Debug */,
+				0A19CA951B0E970E00548B1A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		0A19CAC01B0E9ADA00548B1A /* Build configuration list for PBXNativeTarget "Reachability-Mac" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0A19CAC11B0E9ADA00548B1A /* Debug */,
+				0A19CAC21B0E9ADA00548B1A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0A19CA741B0E970E00548B1A /* Project object */;
+}

--- a/Reachability.xcodeproj/project.pbxproj
+++ b/Reachability.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		0A19CA7D1B0E970E00548B1A /* Reachability.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Reachability.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0A19CA811B0E970E00548B1A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0A19CA821B0E970E00548B1A /* Reachability.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Reachability.h; sourceTree = "<group>"; };
-		0A19CA991B0E973400548B1A /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reachability.swift; path = ../../../../../../../../src/Reachability.swift/Reachability.swift; sourceTree = BUILT_PRODUCTS_DIR; };
+		0A19CA991B0E973400548B1A /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reachability.swift; path = ../Reachability.swift; sourceTree = "<group>"; };
 		0A19CAAD1B0E9ADA00548B1A /* Reachability.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Reachability.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -385,6 +385,7 @@
 				0A19CA951B0E970E00548B1A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		0A19CAC01B0E9ADA00548B1A /* Build configuration list for PBXNativeTarget "Reachability-Mac" */ = {
 			isa = XCConfigurationList;
@@ -393,6 +394,7 @@
 				0A19CAC21B0E9ADA00548B1A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Reachability.xcodeproj/xcshareddata/xcschemes/Reachability-Mac.xcscheme
+++ b/Reachability.xcodeproj/xcshareddata/xcschemes/Reachability-Mac.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0A19CAAC1B0E9ADA00548B1A"
+               BuildableName = "Reachability.framework"
+               BlueprintName = "Reachability-Mac"
+               ReferencedContainer = "container:Reachability.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0A19CAB61B0E9ADA00548B1A"
+               BuildableName = "Reachability-MacTests.xctest"
+               BlueprintName = "Reachability-MacTests"
+               ReferencedContainer = "container:Reachability.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0A19CAB61B0E9ADA00548B1A"
+               BuildableName = "Reachability-MacTests.xctest"
+               BlueprintName = "Reachability-MacTests"
+               ReferencedContainer = "container:Reachability.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0A19CAAC1B0E9ADA00548B1A"
+            BuildableName = "Reachability.framework"
+            BlueprintName = "Reachability-Mac"
+            ReferencedContainer = "container:Reachability.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0A19CAAC1B0E9ADA00548B1A"
+            BuildableName = "Reachability.framework"
+            BlueprintName = "Reachability-Mac"
+            ReferencedContainer = "container:Reachability.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0A19CAAC1B0E9ADA00548B1A"
+            BuildableName = "Reachability.framework"
+            BlueprintName = "Reachability-Mac"
+            ReferencedContainer = "container:Reachability.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Reachability.xcodeproj/xcshareddata/xcschemes/Reachability-iOS.xcscheme
+++ b/Reachability.xcodeproj/xcshareddata/xcschemes/Reachability-iOS.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0A19CA7C1B0E970E00548B1A"
+               BuildableName = "Reachability.framework"
+               BlueprintName = "Reachability-iOS"
+               ReferencedContainer = "container:Reachability.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0A19CA7C1B0E970E00548B1A"
+            BuildableName = "Reachability.framework"
+            BlueprintName = "Reachability-iOS"
+            ReferencedContainer = "container:Reachability.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0A19CA7C1B0E970E00548B1A"
+            BuildableName = "Reachability.framework"
+            BlueprintName = "Reachability-iOS"
+            ReferencedContainer = "container:Reachability.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Reachability.xcworkspace/contents.xcworkspacedata
+++ b/Reachability.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Reachability.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Reachability Sample/Reachability Sample.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Reachability/Info.plist
+++ b/Reachability/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>uk.co.joylordsystems..$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Reachability/Reachability.h
+++ b/Reachability/Reachability.h
@@ -1,0 +1,18 @@
+//
+//  Reachability.h
+//  Reachability
+//
+//  Created by Abizer Nasir on 21/05/2015.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for Reachability.
+FOUNDATION_EXPORT double ReachabilityVersionNumber;
+
+//! Project version string for Reachability.
+FOUNDATION_EXPORT const unsigned char ReachabilityVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Reachability/PublicHeader.h>
+
+


### PR DESCRIPTION
Carthage is a popular decentralised dependency management system. https://github.com/Carthage/Carthage

I've made changes to the project to make it compatible with this system. This doesn't affect the CocoaPod integration because the one file that it uses is still in the same location.

To do this I've made a project that builds Reachability as a framework (one for iOS one for OS X). Also, I've added a workspace and modified the sample project so that it links against the built framework. This is done in a workspace.

You can verify that this builds correctly for Carthage by running:

```
carthage build --no-skip-current
```

from the project root.

You may also wish to change the tag for the project.

Thanks.