### PR TITLE
Fix exec_bad_access if stopNotifier() is called before deinit()

### DIFF
--- a/Reachability.swift
+++ b/Reachability.swift
@@ -149,8 +149,9 @@ public class Reachability: NSObject {
     
 
     public func stopNotifier() {
-
-        SCNetworkReachabilitySetCallback(reachabilityRef!, nil, nil)
+        if let reachabilityRef = reachabilityRef {
+            SCNetworkReachabilitySetCallback(reachabilityRef, nil, nil)
+        }
         reachabilityRef = nil
     }
 


### PR DESCRIPTION
Because deinit() call also stopNotifier() and in this second call reachabilityRef is nil