### PR TITLE
Fix for restart, otherwise SetDispatchQueue in startNotifier fails

### DIFF
--- a/Reachability.swift
+++ b/Reachability.swift
@@ -151,6 +151,7 @@ public class Reachability: NSObject {
     public func stopNotifier() {
         if let reachabilityRef = reachabilityRef {
             SCNetworkReachabilitySetCallback(reachabilityRef, nil, nil)
+            SCNetworkReachabilitySetDispatchQueue(reachabilityRef, nil)
         }
         notifierRunning = false
     }


### PR DESCRIPTION
Calling startNotifier for a second time (after stopNotifier) fails at SetDispatchQueue is a queue is already set.