### PR TITLE
SCNetworkReachibility objects not being freed

### DIFF
--- a/Reachability.swift
+++ b/Reachability.swift
@@ -151,6 +151,7 @@ public class Reachability: NSObject {
     public func stopNotifier() {
         if let reachabilityRef = reachabilityRef {
             SCNetworkReachabilitySetCallback(reachabilityRef, nil, nil)
+            SCNetworkReachabilitySetDispatchQueue(reachabilityRef, nil)
         }
         notifierRunning = false
     }


### PR DESCRIPTION
SCNetworkReachability objects not freed when startNotify called.

Running Reachability.swift under Instrument's Allocation tool showed
SCNetworkReachibility objects not being freed after startNotify was
called.

Calling SCNetworkReachabilitySetDispatchQueue to NULL out the dispatch
queue in stopNotify resolved this issue.