### PR TITLE
Allow startNotifier to optionally skip the initial check.

### DIFF
--- a/Reachability/Reachability.swift
+++ b/Reachability/Reachability.swift
@@ -139,7 +139,7 @@ public class Reachability: NSObject {
     }
 
     // MARK: - *** Notifier methods ***
-    public func startNotifier() throws {
+    public func startNotifier(withImmediateCheck checkImmediately: Bool = true) throws {
 
         guard !notifierRunning else { return }
         
@@ -156,10 +156,12 @@ public class Reachability: NSObject {
             throw ReachabilityError.UnableToSetDispatchQueue
         }
 
-        // Perform an intial check
-        dispatch_async(reachabilitySerialQueue) { () -> Void in
-            let flags = self.reachabilityFlags
-            self.reachabilityChanged(flags)
+        // Perform an intial check if desired.
+        if checkImmediately {
+            dispatch_async(reachabilitySerialQueue) { () -> Void in
+                let flags = self.reachabilityFlags
+                self.reachabilityChanged(flags)
+            }
         }
         
         notifierRunning = true


### PR DESCRIPTION
Because sometimes you only want to know when network *comes back*.
Furthermore, the initial check is not on main thread which can cause some
issues for clients.

Certainly we needed this change to get rid of nasty crashes and difficult thread timing behaviour in our app. In our use case we only cared to know when connectivity was *re-established* for auto-reload functionality. So we didn't want to initial check, and occasionally the initial callback would arrive before the result of startNotifier had actually been assigned, so we didn't have access to the Reachability object (which we wanted to check if we had WiFi or mobile access). Which caused crashes until we figured out what was going on.