### PR TITLE
Added Carthage/Build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ DerivedData
 #
 # Pods/
 .DS_Store
+
+# Carthage
+Carthage/Build


### PR DESCRIPTION
When using the option `--use-submodules` with Carthage, the `Carthage/Build` directory shows in the submodule after `carthage build` making the submodule dirty.