### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Just drop the **Reachability.swift** file into your project. That's it!
 
     ``` ruby
     use_frameworks!
-    pod 'ReachabilitySwift', :git => 'https://github.com/ashleymills/Reachability.swift'
+    pod 'ReachabilitySwift'
     ```
 
  3. Run `pod install`.


### PR DESCRIPTION
Removed the => git for the podfile. It's generally not a good idea to fetch the latest GIT version, specially if there are breaking changes. 
Either way, it doesn't work right now with the git and cocoapods 1.x