### PR TITLE
always embed librararies

### DIFF
--- a/Reachability.xcodeproj/project.pbxproj
+++ b/Reachability.xcodeproj/project.pbxproj
@@ -796,6 +796,7 @@
 		AA7344841BE7678B008AFE69 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -847,6 +848,7 @@
 		AA7344851BE7678B008AFE69 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";


### PR DESCRIPTION
carthage was unable to compile the xcodeproject.

```
carthage update Reachability.swift --platform ios                                          
*** Checking out Reachability.swift at "833482f68b0904b9cdd6abea7e4f146a06627a48"
*** xcodebuild output can be found in /var/folders/dx/1hfzg5g57h744n0dg8r3b7b40000gp/T/carthage-xcodebuild.TUjCSm.log
*** Building scheme "Reachability" in Reachability.xcodeproj
Build Failed
	Task failed with exit code 65:
	/usr/bin/xcrun xcodebuild -project /Users/xinsight/dev/onemedly-ios/OneMedly/Carthage/Checkouts/Reachability.swift/Reachability.xcodeproj -scheme Reachability -configuration Release -derivedDataPath /Users/xinsight/Library/Caches/org.carthage.CarthageKit/DerivedData/Reachability.swift/833482f68b0904b9cdd6abea7e4f146a06627a48 -sdk iphoneos ONLY_ACTIVE_ARCH=NO BITCODE_GENERATION_MODE=bitcode CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES clean build

This usually indicates that project itself failed to compile. Please check the xcodebuild log for more details: /var/folders/dx/1hfzg5g57h744n0dg8r3b7b40000gp/T/carthage-xcodebuild.TUjCSm.log
```

The error was:

```
=== CLEAN TARGET Reachability OF PROJECT Reachability WITH CONFIGURATION Release ===

Check dependencies
“Swift Language Version” (SWIFT_VERSION) is required to be configured correctly for targets which use Swift. Use the [Edit > Convert > To Current Swift Syntax…] menu to choose a Swift version or use the Build Settings editor to configure the build setting directly.
“Swift Language Version” (SWIFT_VERSION) is required to be configured correctly for targets which use Swift. Use the [Edit > Convert > To Current Swift Syntax…] menu to choose a Swift version or use the Build Settings editor to configure the build setting directly.
```

SWIFT_VERSION was set correctly in Reachability - but `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;` was missing. Adding that fixed the problem.