### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ var connection: Connection
 
 ### Other changes:
 
-- `isReachableViaWWAN` has been renamed to `isReachableViaCellular`
-
 - `reachableOnWWAN` has been renamed to `allowsCellularConnection`
 
 - `reachability.currentReachabilityString` has been deprecated. Use `"\(reachability.connection)"` instead.


### PR DESCRIPTION
There is no `isReachableViaCellular` function, maybe it was renamed to that first, but after that you changed your mind and deprecated it to `connection == .cellular`