### PR TITLE
Make Notification.Name extension public

### DIFF
--- a/Reachability/Reachability.swift
+++ b/Reachability/Reachability.swift
@@ -38,7 +38,7 @@ public enum ReachabilityError: Error {
 @available(*, unavailable, renamed: "Notification.Name.reachabilityChanged")
 public let ReachabilityChangedNotification = NSNotification.Name("ReachabilityChangedNotification")
 
-extension Notification.Name {
+public extension Notification.Name {
     public static let reachabilityChanged = Notification.Name("reachabilityChanged")
 }
 


### PR DESCRIPTION
Otherwise, other projects are unable to reference `.reachabilityChanged`. Thanks for an awesome framework!