### PR TITLE
Improve error handling and allow configuring notification queue

### DIFF
--- a/Tests/ReachabilityTests.swift
+++ b/Tests/ReachabilityTests.swift
@@ -14,7 +14,7 @@ class ReachabilityTests: XCTestCase {
     func testValidHost() {
         let validHostName = "google.com"
         
-        guard let reachability = Reachability(hostname: validHostName) else {
+        guard let reachability = try? Reachability(hostname: validHostName) else {
             return XCTFail("Unable to create reachability")
         }
         
@@ -47,7 +47,7 @@ class ReachabilityTests: XCTestCase {
 
         let invalidHostName = "invalidhost"
 
-        guard let reachability = Reachability(hostname: invalidHostName) else {
+        guard let reachability = try? Reachability(hostname: invalidHostName) else {
             return XCTFail("Unable to create reachability")
         }
         


### PR DESCRIPTION
## Changes
- Improved error handling:

  + Updated `ReachabilityError` to contain the error code returned by `SCError()` after an error occurs.

  + Made all calls to `SystemConfiguration`'s API produce and propagate the error. This affected some `init`'s, which now throw instead of returning an optional.

  + Renamed error cases to start with lowercase, according to Swift's error guidelines.

- Allow configuring the notification `DispatchQueue`, which was previously hardcoded to `DispatchQueue.main`. It is now an optional, which if set to `nil` will use the notifier's internal queue to fire notifications. The default is still `.main`.

- Minor clean ups