### PR TITLE
Link CoreTelephony.framework required in iOS 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [4.3.1] - 2018-10-18
+### Fixed 
+- Link CoreTelephony.framework required in iOS 12
+
 ## [4.3.0] - 2018-10-01
 ### Changed 
 - Updates for Swift 4.2

--- a/ReachabilitySwift.podspec
+++ b/ReachabilitySwift.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   }
   s.source_files = 'Sources/Reachability.swift'
   s.framework    = 'SystemConfiguration'
-  s.framework    = 'CoreTelephony'
+  s.ios.framework    = 'CoreTelephony'
 
   s.requires_arc = true
 end

--- a/ReachabilitySwift.podspec
+++ b/ReachabilitySwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'ReachabilitySwift'
-  s.version      = '4.3.0'
+  s.version      = '4.3.1'
   s.module_name = 'Reachability'
   s.homepage     = 'https://github.com/ashleymills/Reachability.swift'
   s.authors      = {
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
   }
   s.source_files = 'Sources/Reachability.swift'
   s.framework    = 'SystemConfiguration'
+  s.framework    = 'CoreTelephony'
 
   s.requires_arc = true
 end

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.3.0</string>
+	<string>4.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
What version of Reachability.Swift are you using?
4.3.0

How is it installed? Manually, CocoaPods, Carthage?
CocoaPods

Does it occur on device or simulator? Which device?
Both. Using iPhone XS Max as an example.

What OS version are you running on?
iOS 12.0

How often does it happen?
Always

Are there steps you can take to reproduce it?
1. Create a new project
2. Add Reachability as a dependency using CocoaPods
3. Build and launch the app without a reachable network. The framework behaves as expected.
4. Without closing the app, turn on WiFi or turn off Airpline mode. The framework still says there is no network until the app is closed and relaunched.

Linking CoreTelephony.framework fixes the problem.