### PR TITLE
Update README.md; compatible iOS version 12.0 -> 13.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Reachability.swift is a replacement for Apple's Reachability sample, re-written in Swift with closures.
 
-It is compatible with **iOS** (8.0 - 12.0), **OSX** (10.9 - 10.14) and **tvOS** (9.0 - 12.0)
+It is compatible with **iOS** (8.0 - 13.2), **OSX** (10.9 - 10.14) and **tvOS** (9.0 - 12.0)
 
 Inspired by https://github.com/tonymillion/Reachability
 


### PR DESCRIPTION
## what I did

I updated README.md. Compatible iOS version, 12.0 -> 13.2.

## what I checked

I checked behaviors on the simulator and the real device.

- Xcode 11.2.1 simulator (iOS 13.2)
- iPhone Xs (iOS 13.1.3)

Reachability.swift works fine.

---

Please merge this pull request, if it has no problems.