### PR TITLE
Swift PM Min Version Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,13 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "Reachability",
+    platforms: [
+         .macOS(.v10_10), .iOS(.v8), .tvOS(.v9)
+    ],
     products: [
         .library(
             name: "Reachability",


### PR DESCRIPTION
Need an iOS_10 support for SwiftPM for the project.
note: Mac(v10_10) - is the minimum available(no 10.9)
 