### PR TITLE
Add Privacy Manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -14,7 +14,9 @@ let package = Package(
         .target(
             name: "Reachability",
             dependencies: [],
-            path: "Sources"),
+            path: "Sources",
+            resources: [.copy("PrivacyInfo.xcprivacy")]
+        ),
         .testTarget(
             name: "ReachabilityTests",
             dependencies: ["Reachability"],

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+   PrivacyInfo.xcprivacy
+   Reachability
+
+   Created by tommyhan on 2/1/2024.
+   Copyright (c) 2024 Ashley Mills. All rights reserved.
+-->
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Reachability.xcodeproj/project.pbxproj
+++ b/Reachability.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		00C54B241C09CF68001C3F12 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C54B231C09CF68001C3F12 /* ViewController.swift */; };
 		00C54B261C09CF68001C3F12 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 00C54B251C09CF68001C3F12 /* Assets.xcassets */; };
 		00C54B291C09CF68001C3F12 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 00C54B271C09CF68001C3F12 /* Main.storyboard */; };
+		038915562B43EF8500FF33BB /* PrivacyInfo.xcprivacy in CopyFiles */ = {isa = PBXBuildFile; fileRef = 038915522B43EEDF00FF33BB /* PrivacyInfo.xcprivacy */; };
 		335AD58E2052EA92000D4D08 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335AD5882052EA92000D4D08 /* Reachability.swift */; };
 		335AD58F2052EA92000D4D08 /* Reachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 335AD5892052EA92000D4D08 /* Reachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		335AD5A22052EB32000D4D08 /* ReachabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335AD58C2052EA92000D4D08 /* ReachabilityTests.swift */; };
@@ -64,6 +65,16 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		038915552B43EF7100FF33BB /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 7;
+			files = (
+				038915562B43EF8500FF33BB /* PrivacyInfo.xcprivacy in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		57A45A361C197F4800384AE4 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -106,7 +117,7 @@
 		00C54B251C09CF68001C3F12 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		00C54B281C09CF68001C3F12 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		00C54B2A1C09CF68001C3F12 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		038915512B43EB0E00FF33BB /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		038915522B43EEDF00FF33BB /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		335AD5882052EA92000D4D08 /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
 		335AD5892052EA92000D4D08 /* Reachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Reachability.h; sourceTree = "<group>"; };
 		335AD58A2052EA92000D4D08 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -193,6 +204,7 @@
 		335AD5872052EA92000D4D08 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				038915522B43EEDF00FF33BB /* PrivacyInfo.xcprivacy */,
 				335AD5882052EA92000D4D08 /* Reachability.swift */,
 				335AD5892052EA92000D4D08 /* Reachability.h */,
 				335AD58A2052EA92000D4D08 /* Info.plist */,
@@ -237,7 +249,6 @@
 				CA6187601F8D21D700FD5234 /* CONTRIBUTING.md */,
 				CA6187611F8D21D700FD5234 /* LICENSE */,
 				CA6187621F8D21D700FD5234 /* ReachabilitySwift.podspec */,
-				038915512B43EB0E00FF33BB /* PrivacyInfo.xcprivacy */,
 				335AD5872052EA92000D4D08 /* Sources */,
 				335AD58B2052EA92000D4D08 /* Tests */,
 				AA7344911BE76820008AFE69 /* ReachabilitySample */,
@@ -348,6 +359,7 @@
 			buildConfigurationList = AA7344861BE7678B008AFE69 /* Build configuration list for PBXNativeTarget "Reachability" */;
 			buildPhases = (
 				AA73446D1BE7678B008AFE69 /* Sources */,
+				038915552B43EF7100FF33BB /* CopyFiles */,
 				AA73446E1BE7678B008AFE69 /* Frameworks */,
 				AA73446F1BE7678B008AFE69 /* Headers */,
 				AA7344701BE7678B008AFE69 /* Resources */,

--- a/Reachability.xcodeproj/project.pbxproj
+++ b/Reachability.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		00C54B251C09CF68001C3F12 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		00C54B281C09CF68001C3F12 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		00C54B2A1C09CF68001C3F12 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		038915512B43EB0E00FF33BB /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		335AD5882052EA92000D4D08 /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
 		335AD5892052EA92000D4D08 /* Reachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Reachability.h; sourceTree = "<group>"; };
 		335AD58A2052EA92000D4D08 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -236,6 +237,7 @@
 				CA6187601F8D21D700FD5234 /* CONTRIBUTING.md */,
 				CA6187611F8D21D700FD5234 /* LICENSE */,
 				CA6187621F8D21D700FD5234 /* ReachabilitySwift.podspec */,
+				038915512B43EB0E00FF33BB /* PrivacyInfo.xcprivacy */,
 				335AD5872052EA92000D4D08 /* Sources */,
 				335AD58B2052EA92000D4D08 /* Tests */,
 				AA7344911BE76820008AFE69 /* ReachabilitySample */,

--- a/ReachabilitySwift.podspec
+++ b/ReachabilitySwift.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
     :tag => 'v'+s.version.to_s
   }
   s.source_files = 'Sources/Reachability.swift'
+  s.resource_bundles = {"Kingfisher" => ["Sources/PrivacyInfo.xcprivacy"]}
   s.framework    = 'SystemConfiguration'
   s.ios.framework    = 'CoreTelephony'
 

--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!--
-   PrivacyInfo.xcprivacy
-   Reachability
-
-   Created by tommyhan on 2/1/2024.
-   Copyright (c) 2024 Ashley Mills. All rights reserved.
--->
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict/>
+	</array>
+</dict>
 </plist>

--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -3,8 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-		<dict/>
-	</array>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
As required by Apple, reachability needs to add privacy manifest to the source code.

If there are any problems please feel free to review, thanks.

Related Issue: #400 