### PR TITLE
Fix to add missing keys for `PrivacyInfo.xcprivacy`

### DIFF
--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array/>
 </dict>


### PR DESCRIPTION
Resolve #405.

The [document](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files) says this, but it doesn't seem to mean that you can omit the key. (Maybe it's a bug in report generation)
> You only need to supply NSPrivacyAccessedAPITypes for apps and third-party SDKs on iOS, iPadOS, tvOS, visionOS, and watchOS.