### PR TITLE
Fix privacy report generation

### DIFF
--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -7,8 +7,23 @@
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array/>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string></string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array/>
+	<array>
+		<dict/>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Adds empty items to CollectedDataType and APITypes
<img width="1645" alt="Screenshot 2024-04-15 at 10 44 57" src="https://github.com/ashleymills/Reachability.swift/assets/165006533/54dfc5b1-f1e1-412b-b9e8-b5481aec1183">
