### PR TITLE
fixed privacy manifest

### DIFF
--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -7,23 +7,8 @@
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string></string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string></string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-		<dict/>
-	</array>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
When submitting to the App Store I'm getting the error:

> ITMS-91056: Invalid privacy manifest - The PrivacyInfo.xcprivacy file from the following path is invalid: “Frameworks/Reachability.framework/PrivacyInfo.xcprivacy”.

I'm not 100% sure what it is but I'm guessing it's the empty items in the manifest. A quick google search found at least one other popular github repo that applied the same fix: https://github.com/apollographql/apollo-ios/compare/main...fix/privacy-manifests

I haven't had a need to submit a new build to the App Store just yet so take it with a grain of salt but I'm guessing it's the correct fix. Since this may become a problem on May 1st I thought I'd submit this here.