### PR TITLE
Removing unused key from manifest file.

### DIFF
--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -4,11 +4,5 @@
 <dict>
 	<key>NSPrivacyTracking</key>
 	<false/>
-	<key>NSPrivacyTrackingDomains</key>
-	<array/>
-	<key>NSPrivacyCollectedDataTypes</key>
-	<array/>
-	<key>NSPrivacyAccessedAPITypes</key>
-	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
Removed the unused privacy keys for removing warning from Apple.

ITMS-91108: Invalid privacy manifest - The PrivacyInfo.xcprivacy file from the following path is invalid: “Frameworks/Reachability.framework/ReachabilitySwift.bundle/PrivacyInfo.xcprivacy”. In addition to the privacy manifest files in the locations outlined in the documentation, starting November 12, 2024, all privacy manifests you submit must have valid content. Keys and values in any privacy manifest must be in a valid format.