### PR TITLE
Update privacy manifest file

### DIFF
--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -2,7 +2,28 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPrivacyTracking</key>
-	<false/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string></string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string></string>
+            </array>
+        </dict>
+    </array>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict/>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
This pull request updates the privacy manifest file to contain the minimum information required by Apple.

## Preview

The screenshots below are from the privacy report generated by Xcode. For more information, please refer to [Create your app's privacy report](https://developer.apple.com/documentation/bundleresources/describing-data-use-in-privacy-manifests#Create-your-apps-privacy-report).


### Before 
<img src="https://github.com/user-attachments/assets/a02e4539-c119-481a-b5aa-4505a00e8493" />


### After
<img src="https://github.com/user-attachments/assets/57665fe8-c6e0-4b05-8120-af46608d1344" />



